### PR TITLE
overview screen prototype

### DIFF
--- a/frontend/App.vue
+++ b/frontend/App.vue
@@ -1,26 +1,54 @@
 <template>
-  <img alt="Vue logo" src="./assets/logo.png">
-  <HelloWorld msg="Welcome to Your Vue.js App"/>
+  <Header title="Overview"></Header>
+  <NavBar></NavBar>
+  <div class="space">
+    <MgmtClusterList></MgmtClusterList>
+    <WorkloadClusterList></WorkloadClusterList>
+  </div>
 </template>
 
 <script>
-import HelloWorld from './components/HelloWorld.vue'
+import Header from './components/Header'
+import NavBar from './components/NavBar'
+import MgmtClusterList from './components/management/ClusterList'
+import WorkloadClusterList from './components/workload/ClusterList'
 
 export default {
   name: 'App',
   components: {
-    HelloWorld
+    Header,
+    NavBar,
+    MgmtClusterList,
+    WorkloadClusterList,
   }
 }
 </script>
 
 <style>
+html, body {
+  height: 100%
+}
+
+body {
+  background: whitesmoke;
+}
+
 #app {
+  height: 100%;
   font-family: Avenir, Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-align: center;
   color: #2c3e50;
   margin-top: 60px;
+}
+
+.navbar {
+  padding-top: 20px;
+  float: left;
+}
+
+.space {
+  width: 100%;
 }
 </style>

--- a/frontend/components/Header.vue
+++ b/frontend/components/Header.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="header">
+    <p>{{ title }}</p>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "Header",
+  props: ["title"],
+}
+</script>
+
+<style scoped>
+  .header {
+    display: flex;
+    background: royalblue;
+    align-items: center;
+    width: 100%;
+    height: 70px;
+  }
+  .header p {
+    font-size: 2em;
+    float: left;
+    color: white;
+    padding-left: 20px;
+  }
+</style>

--- a/frontend/components/NavBar.vue
+++ b/frontend/components/NavBar.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="navbar">
+    <ul>
+      <li><a href=""><b>Management clusters</b></a></li>
+      <li><a href=""><b>Workload clusters</b></a></li>
+      <li><a href=""><b>Providers</b></a></li>
+    </ul>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "NavBar"
+}
+</script>
+
+<style scoped>
+  * {
+    margin: 0px;
+    padding: 0px;
+  }
+
+  .navbar {
+    width: 250px;
+    height: 100%;
+  }
+
+  .navbar ul {
+    padding-left: 25px;
+    text-align: left;
+    list-style: none;
+    line-height: 50px;
+    list-style: '+ ';
+  }
+
+  .navbar a {
+    color: black;
+    text-decoration: none;
+  }
+</style>

--- a/frontend/components/Overview.vue
+++ b/frontend/components/Overview.vue
@@ -1,0 +1,18 @@
+<template>
+
+</template>
+
+<script>
+import NavBar from './NavBar.vue'
+
+export default {
+  name: "Overview",
+  components: {
+    NavBar,
+  }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/frontend/components/management/AddButton.vue
+++ b/frontend/components/management/AddButton.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="add-mgmnt-clstr-btn">
+    <button>Add cluster</button>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "AddButton"
+}
+</script>
+
+<style scoped>
+  button {
+    border: 5px solid royalblue;
+    background: royalblue;
+    color: white;
+    font-size: 1em;
+    border-radius: 5px;
+  }
+</style>

--- a/frontend/components/management/ClusterList.vue
+++ b/frontend/components/management/ClusterList.vue
@@ -1,0 +1,109 @@
+<template>
+  <div class="wrapper">
+    <p><b>Management clusters</b></p>
+    <div class="cluster-list">
+      <div class="header">
+        <AddButton></AddButton>
+      </div>
+      <table>
+        <tr>
+          <th>Name</th>
+          <th>Available</th>
+          <th>Pending</th>
+          <th>Failed</th>
+          <th>Provider</th>
+          <th>Created</th>
+          <th>Updated</th>
+        </tr>
+        <tr>
+          <td><a href="">capi-mgmt-cluster-01</a></td>
+          <td><b class="available">2</b>/<b class="total">2</b></td>
+          <td><b class="pending">0</b></td>
+          <td><b class="failed">0</b></td>
+          <td><a href="">Cluster API</a></td>
+          <td>26-08-2021:12:00:00</td>
+          <td>26-08-2021:12:00:00</td>
+        </tr>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script>
+import AddButton from './AddButton'
+
+export default {
+  name: "ClusterList",
+  components: {
+    AddButton,
+  }
+}
+</script>
+
+<style scoped>
+  p {
+    font-size: 1.5em;
+    text-align: left;
+    color: dimgray;
+  }
+
+  table {
+    font-family: arial, sans-serif;
+    border-collapse: collapse;
+    width: 100%;
+  }
+
+  th {
+    color: gray;
+  }
+
+  th, td {
+    padding: 8px;
+  }
+
+  tr:nth-child(even) {
+    background-color: whitesmoke;
+  }
+
+  .available {
+    color: green;
+  }
+
+  .total {
+    color: green;
+  }
+
+  .pending {
+    color: orange;
+  }
+
+  .failed {
+    color: red;
+  }
+
+  .wrapper {
+    float: left;
+    width: 50%;
+  }
+
+  .cluster-list {
+    box-shadow: 0 3px 1px -2px rgba(0, 0, 0, .2), 0 2px 2px 0 rgba(0, 0, 0, .14), 0 1px 5px 0 rgba(0, 0, 0, .12);
+    background: white;
+    border-radius: 5px;
+  }
+
+  .header {
+    display: inline-block;
+    width: 100%;
+  }
+
+  .cluster-cards {
+    padding: 10px;
+  }
+
+  .add-mgmnt-clstr-btn {
+    float: right;
+    padding-right: 10px;
+    padding-top: 10px;
+  }
+</style>

--- a/frontend/components/workload/ClusterList.vue
+++ b/frontend/components/workload/ClusterList.vue
@@ -1,0 +1,131 @@
+<template>
+  <div class="wrapper">
+    <p><b>Workload clusters</b></p>
+
+    <div class="cluster-list">
+      <div class="header">
+        <CreateButton></CreateButton>
+      </div>
+      <table>
+        <tr>
+          <th>Name</th>
+          <th>Available</th>
+          <th>Pending</th>
+          <th>Fail</th>
+          <th>Management</th>
+          <th>Provider</th>
+          <th>Created</th>
+          <th>Updated</th>
+        </tr>
+        <tr>
+          <td><a href="">capi-workload-cluster-00</a></td>
+          <td><b class="available">5</b>/<b class="total">5</b></td>
+          <td><b class="pending">0</b></td>
+          <td><b class="failed">0</b></td>
+          <td><a href="">capi-mgmt-cluster-01</a></td>
+          <td><a href="">Cluster API</a></td>
+          <td>26-08-2021:12:00:00</td>
+          <td>26-08-2021:12:00:00</td>
+        </tr>
+        <tr>
+          <td><a href="">capi-workload-cluster-01</a></td>
+          <td><b class="pending">4</b>/<b class="total">5</b></td>
+          <td><b class="pending">1</b></td>
+          <td><b class="failed">0</b></td>
+          <td><a href="">capi-mgmt-cluster-01</a></td>
+          <td><a href="">Cluster API</a></td>
+          <td>26-08-2021:12:00:00</td>
+          <td>26-08-2021:12:00:00</td>
+        </tr>
+        <tr>
+          <td><a href="">capi-workload-cluster-02</a></td>
+          <td><b class="failed">3</b>/<b class="total">5</b></td>
+          <td><b class="pending">1</b></td>
+          <td><b class="failed">1</b></td>
+          <td><a href="">capi-mgmt-cluster-01</a></td>
+          <td><a href="">Cluster API</a></td>
+          <td>26-08-2021:12:00:00</td>
+          <td>26-08-2021:12:00:00</td>
+        </tr>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script>
+import CreateButton from './CreateButton'
+
+export default {
+  name: "ClusterList",
+  components: {
+    CreateButton,
+  }
+}
+</script>
+
+<style scoped>
+p {
+  font-size: 1.5em;
+  text-align: left;
+  color: dimgray;
+}
+
+table {
+  font-family: arial, sans-serif;
+  border-collapse: collapse;
+}
+
+th {
+  color: gray;
+}
+
+th, td {
+  padding: 8px;
+}
+
+tr:nth-child(even) {
+  background-color: whitesmoke;
+}
+
+.available {
+  color: green;
+}
+
+.total {
+  color: green;
+}
+
+.pending {
+  color: orange;
+}
+
+.failed {
+  color: red;
+}
+
+.wrapper {
+  float: left;
+  width: 50%
+}
+
+.cluster-list {
+  box-shadow: 0 3px 1px -2px rgba(0, 0, 0, .2), 0 2px 2px 0 rgba(0, 0, 0, .14), 0 1px 5px 0 rgba(0, 0, 0, .12);
+  background: white;
+  border-radius: 5px;
+}
+
+.header {
+  display: inline-block;
+  width: 100%;
+}
+
+.cluster-cards {
+  padding: 10px;
+}
+
+.create-wrk-clstr-btn {
+  float: right;
+  padding-right: 10px;
+  padding-top: 10px;
+}
+</style>

--- a/frontend/components/workload/CreateButton.vue
+++ b/frontend/components/workload/CreateButton.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="create-wrk-clstr-btn">
+    <button>Create cluster</button>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "CreateButton"
+}
+</script>
+
+<style scoped>
+button {
+  border: 5px solid royalblue;
+  background: royalblue;
+  color: white;
+  font-size: 1em;
+  border-radius: 5px;
+}
+</style>


### PR DESCRIPTION
Prototype of `Overview` screen. It's purpose is to show status of all management and workload clusters and allow to quickly access detailed info about specific cluster.

![interface](https://user-images.githubusercontent.com/3637857/130966407-755e473b-8305-4f61-8087-b5c78af1be6f.png)
