### PR TITLE
API skeleton

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,10 +4,11 @@ import (
 	"flag"
 	"net/http"
 
-	"github.com/klaven/capi-cp/pkg/routes"
 	"github.com/rancher/wrangler/pkg/kubeconfig"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/klaven/capi-cp/pkg/routes"
 )
 
 var (

--- a/pkg/routes/mgmt.go
+++ b/pkg/routes/mgmt.go
@@ -12,32 +12,32 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var (
-	capiRoute = "/capi"
+const (
+	mgmtRoute = "/mgmt"
 )
 
-func getCapiBaseRoute() string {
-	return baseRoute + capiRoute
+func getMgmtBaseRoute() string {
+	return baseRouteV1 + mgmtRoute
 }
 
-type CapiRouter struct {
+type MgmtRouter struct {
 	Client client.Client
 }
 
-func NewCapiRouter(client client.Client) *CapiRouter {
-	return &CapiRouter{Client: client}
+func NewMgmtRouter(client client.Client) *MgmtRouter {
+	return &MgmtRouter{Client: client}
 }
 
-func (c *CapiRouter) AddCapiRoutes(router *mux.Router) {
-	router.HandleFunc(getCapiBaseRoute()+"/clusters", c.handleGetClusters).Methods("GET")
+func (c *MgmtRouter) AddRoutes(router *mux.Router) {
+	router.HandleFunc(getMgmtBaseRoute()+"/clusters", c.handleGetClusters).Methods("GET")
 }
 
-func handleCapiRoute(responseWriter http.ResponseWriter, request *http.Request) {
+func handleMgmtRoute(responseWriter http.ResponseWriter, request *http.Request) {
 	responseWriter.WriteHeader(http.StatusOK)
 	fmt.Fprintf(responseWriter, "Something for sure")
 }
 
-func (c *CapiRouter) handleGetClusters(responseWriter http.ResponseWriter, request *http.Request) {
+func (c *MgmtRouter) handleGetClusters(responseWriter http.ResponseWriter, request *http.Request) {
 	responseWriter.Header().Set("Context-Type", "application/x-www-form-urlencoded")
 	responseWriter.Header().Set("Access-Control-Allow-Origin", "*")
 	clusters := &v1alpha4.ClusterList{}
@@ -50,7 +50,7 @@ func (c *CapiRouter) handleGetClusters(responseWriter http.ResponseWriter, reque
 	json.NewEncoder(responseWriter).Encode("No Cluster Created Yet!!!")
 }
 
-func (c *CapiRouter) handleGetCluster(responseWriter http.ResponseWriter, request *http.Request) {
+func (c *MgmtRouter) handleGetCluster(responseWriter http.ResponseWriter, request *http.Request) {
 	responseWriter.Header().Set("Context-Type", "application/x-www-form-urlencoded")
 	responseWriter.Header().Set("Access-Control-Allow-Origin", "*")
 

--- a/pkg/routes/providers.go
+++ b/pkg/routes/providers.go
@@ -1,0 +1,24 @@
+package routes
+
+import (
+	"github.com/gorilla/mux"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	providersRoute = "/providers"
+)
+
+func getProvidersBaseRoute() string {
+	return baseRouteV1 + providersRoute
+}
+
+type ProvidersRouter struct {
+	Client client.Client
+}
+
+func NewProvidersRouter(client client.Client) *ProvidersRouter {
+	return &ProvidersRouter{Client: client}
+}
+
+func (c *ProvidersRouter) AddRoutes(router *mux.Router) {}

--- a/pkg/routes/routes.go
+++ b/pkg/routes/routes.go
@@ -7,8 +7,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var (
-	baseRoute = "/api/v1"
+const (
+	baseRouteV1 = "/api/v1"
 )
 
 func StartRouter(client client.Client) *mux.Router {
@@ -16,9 +16,14 @@ func StartRouter(client client.Client) *mux.Router {
 
 	AddKubernetesRoutes(router)
 
-	capiRouter := NewCapiRouter(client)
+	mgmtRouter := NewMgmtRouter(client)
+	mgmtRouter.AddRoutes(router)
 
-	capiRouter.AddCapiRoutes(router)
+	workloadRouter := NewWorkloadRouter(client)
+	workloadRouter.AddRoutes(router)
+
+	providersRouter := NewProvidersRouter(client)
+	providersRouter.AddRoutes(router)
 
 	http.Handle("/", router)
 

--- a/pkg/routes/workload.go
+++ b/pkg/routes/workload.go
@@ -1,0 +1,24 @@
+package routes
+
+import (
+	"github.com/gorilla/mux"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	workloadRoute = "/workload"
+)
+
+func getWorkloadBaseRoute() string {
+	return baseRouteV1 + workloadRoute
+}
+
+type WorkloadRouter struct {
+	Client client.Client
+}
+
+func NewWorkloadRouter(client client.Client) *WorkloadRouter {
+	return &WorkloadRouter{Client: client}
+}
+
+func (c *WorkloadRouter) AddRoutes(router *mux.Router) {}


### PR DESCRIPTION
Updated API skeleton. Now there's 3 main routes:
- `/mgmt` -- management clusters base route.
- `/workload` -- workload clusters base route.
- `/providers` -- providers base route.

That should provide some flexibility for the future, in case projects other than CAPI will be supported(by project itself or by third parties).